### PR TITLE
Fix: Balance message for victory case is misleading without mentioning costs

### DIFF
--- a/src/main/java/edu/northeastern/cs5500/starterbot/model/NPCBattle.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/model/NPCBattle.java
@@ -291,8 +291,9 @@ public class NPCBattle {
 
         builder.append("💰 Trainer's Bounty 💰\n");
         builder.append(BOARD_LINE);
-        builder.append("   Coins Earned 🪙 : +").append(coinsEarned).append("\n");
-        builder.append("   New Balance  💸 :  ").append(trainer.getBalance()).append("\n\n");
+        builder.append("   Coins Earned 🤑 : +").append(coinsEarned).append("\n");
+        builder.append("   Battle Cost  💸 : -").append(COST_PER_BATTLE).append("\n");
+        builder.append("   New Balance  💰 :  ").append(trainer.getBalance()).append("\n\n");
 
         builder.append("🌈 Celebrate this victory. The journey to greatness continues!\n");
 
@@ -340,7 +341,7 @@ public class NPCBattle {
 
         builder.append("💸 Trainer's Expense 💸\n");
         builder.append(BOARD_LINE);
-        builder.append("   Battle Cost 🪙  : -").append(COST_PER_BATTLE).append("\n");
+        builder.append("   Battle Cost 💸  : -").append(COST_PER_BATTLE).append("\n");
         builder.append("   New Balance 💰  :  ").append(trainer.getBalance()).append("\n\n");
 
         builder.append("🌟 Every battle is a lesson. Your next victory awaits!\n");


### PR DESCRIPTION
close #109 

--- 

Below are message copied from TEST RUN without modification, covering four cases:
1. victory + no level up 
2. victory + with level up 
3. defeat + no level up
4. defeat + with level up

This is a follow up to concerns of LEVEL UP message as discussed in https://github.com/CS5500-F-2023/bot-falcon/pull/100#issuecomment-1839889654 

--- 

```
🌟🏆🌟 VICTORY ACHIEVED! 🌟🏆🌟

🎉 A splendid triumph, your Aipom shines in glory!

🔥 Aipom's Rewards 🔥
----------------------------
   XP Spark     🌟 : +40
   Current XP   🏆 :  58

💰 Trainer's Bounty 💰
----------------------------
   Coins Earned 🤑 : +20
   Battle Cost  💸 : -5
   New Balance  💰 :  61

🌈 Celebrate this victory. The journey to greatness continues!
```

```
🌟🏆🌟 VICTORY ACHIEVED! 🌟🏆🌟

🎉 A splendid triumph, your Aipom shines in glory!

🔥 Aipom's Rewards 🔥
----------------------------
   XP Spark     🌟 : +40
   Current XP   🏆 :  34
   LEVEL UP to  🚀 :  7

💰 Trainer's Bounty 💰
----------------------------
   Coins Earned 🤑 : +20
   Battle Cost  💸 : -5
   New Balance  💰 :  87

🌈 Celebrate this victory. The journey to greatness continues!
```

```
💥🛡️💥 BATTLE CONCLUDED 💥🛡️💥

💔 Tough luck, your Aipom bravely faced the challenge!

🔥 Aipom's Gains 🔥
----------------------------
   XP Earned    🌟 : +19
   Current XP   🏆 :  31

💸 Trainer's Expense 💸
----------------------------
   Battle Cost 💸  : -5
   New Balance 💰  :  110

🌟 Every battle is a lesson. Your next victory awaits!
```


```
💥🛡️💥 BATTLE CONCLUDED 💥🛡️💥

💔 Tough luck, your Aipom bravely faced the challenge!

🔥 Aipom's Gains 🔥
----------------------------
   XP Earned    🌟 : +17
   Current XP   🏆 :  6
   LEVEL UP to  🚀 :  11

💸 Trainer's Expense 💸
----------------------------
   Battle Cost 💸  : -5
   New Balance 💰  :  148

🌟 Every battle is a lesson. Your next victory awaits!

```